### PR TITLE
add read in state listLinks

### DIFF
--- a/src/components/modal/AddLinkModal/AddLinkModal.jsx
+++ b/src/components/modal/AddLinkModal/AddLinkModal.jsx
@@ -14,6 +14,7 @@ const INITIAL_STATE = {
     url: '',
     descriptionLink: '',
     currentGroup: '',
+    read: false,
 }
 
 export default function AddLinkModal({isOpen, handleOpen}) {
@@ -33,6 +34,7 @@ export default function AddLinkModal({isOpen, handleOpen}) {
 
     const handleChangeCheckbox = (event) => {
         setChecked(event.target.checked)
+        setBookmark({...bookmark, read: event.target.checked})
     }
 
     const handleSubmit = (e) => {

--- a/src/components/modal/AddLinkModal/useForm.jsx
+++ b/src/components/modal/AddLinkModal/useForm.jsx
@@ -5,7 +5,6 @@ import {FormControl, InputLabel, MenuItem, Select, Checkbox, FormControlLabel} f
 export function useForm(initialValue) {
     const [bookmark, setBookmark] = React.useState(initialValue)
     const [error, setError] = React.useState({})
-    const [checked, setChecked] = React.useState(false)
 
     const groups = useSelector((state) => state.listGroups)
 
@@ -17,10 +16,10 @@ export function useForm(initialValue) {
     }
 
     const handleChangeCheckbox = (event) => {
-        setChecked((prevState) => !prevState)
+        setBookmark({...bookmark, read: event.target.checked})
     }
 
-    const select = checked ? (
+    const select = bookmark.read ? (
         <div>Список для чтения</div>
     ) : (
         <FormControl fullWidth margin="normal">
@@ -36,7 +35,10 @@ export function useForm(initialValue) {
     )
 
     const box = (
-        <FormControlLabel control={<Checkbox checked={checked} onChange={handleChangeCheckbox} />} label="Список для чтения" />
+        <FormControlLabel
+            control={<Checkbox checked={bookmark.read} onChange={handleChangeCheckbox} />}
+            label="Список для чтения"
+        />
     )
 
     const validate = () => {
@@ -60,8 +62,6 @@ export function useForm(initialValue) {
         error,
         setError,
         select,
-        checked,
-        setChecked,
         groups,
         box,
     }

--- a/src/components/modal/EditModal/EditModal.jsx
+++ b/src/components/modal/EditModal/EditModal.jsx
@@ -12,6 +12,7 @@ function EditModal({link, isOpen, handleOpen}) {
         url: link.url,
         descriptionLink: link.descriptionLink,
         currentGroup: link.currentGroup,
+        read: link.read,
     }
 
     const {bookmark, setBookmark, validate, error, setError, select, checked, groups, box} = useForm(INITIAL_STATE)
@@ -23,7 +24,7 @@ function EditModal({link, isOpen, handleOpen}) {
 
         const payload = {
             ...bookmark,
-            currentGroup: checked ? 'Список для чтения' : bookmark.currentGroup,
+            currentGroup: bookmark.read ? 'Список для чтения' : bookmark.currentGroup,
         }
 
         if (validate()) {


### PR DESCRIPTION
Added a new line "read" to the state for the correct operation of the modal window for editing links.
Deleted the variable for testing, as it turned out to be unnecessary.

But I did not touch the "checked" variable in the "AddLinkModal" component.